### PR TITLE
Fix FSA bugs

### DIFF
--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from 'react'
-import { useProjectStore, useSelectionStore } from '/src/stores'
+import { useProjectStore, useSelectionStore, useViewStore } from '/src/stores'
 import { VIEW_MOVE_STEP } from '/src/config/interactions'
 import { convertJFLAPXML } from '@automatarium/jflap-translator'
 

--- a/frontend/src/pages/Editor/components/Sidepanel/Panels/TestingLab/TestingLab.js
+++ b/frontend/src/pages/Editor/components/Sidepanel/Panels/TestingLab/TestingLab.js
@@ -38,7 +38,6 @@ const TestingLab = () => {
     result = {
       accepted,
       remaining,
-      // trace: trace.read === '' ? 'lam' : trace.read
       trace: trace.map(step => ({
         to: step.to,
         read: step.read === '' ? 'λ' : step.read
@@ -70,7 +69,9 @@ const TestingLab = () => {
 
     // Add rejecting transition if applicable
     const transitionsWithRejected = !accepted && traceIdx === trace.length
-      ? [...transitions, `${remaining[0]}: ${statePrefix}${trace[trace.length-1].to} ->|`]
+      ? [...transitions,
+        remaining[0] && `${remaining[0]}: `,
+        `${statePrefix}${trace[trace.length-1].to} ->|`]
       : transitions
 
     // Add 'REJECTED'/'ACCEPTED' label

--- a/frontend/src/pages/Editor/components/Sidepanel/Panels/TestingLab/TestingLab.js
+++ b/frontend/src/pages/Editor/components/Sidepanel/Panels/TestingLab/TestingLab.js
@@ -70,8 +70,9 @@ const TestingLab = () => {
     // Add rejecting transition if applicable
     const transitionsWithRejected = !accepted && traceIdx === trace.length
       ? [...transitions,
-        remaining[0] && `${remaining[0]}: `,
-        `${statePrefix}${trace[trace.length-1].to} ->|`]
+        remaining[0] ?
+          `${remaining[0]}: ${statePrefix}${trace[trace.length-1].to} ->|`
+          : `\n${statePrefix}${trace[trace.length-1].to} ->|`]
       : transitions
 
     // Add 'REJECTED'/'ACCEPTED' label
@@ -119,7 +120,7 @@ const TestingLab = () => {
             onClick={() => {
               // Increment tracer index
               const result = simulationResult ?? simulateGraph()
-              setTraceIdx(result.trace.length)
+              setTraceIdx(result.trace.length - (result.accepted ? 1 : 0))
             }} />
         </StepButtons>
 

--- a/packages/simulation/src/simulateFSA.js
+++ b/packages/simulation/src/simulateFSA.js
@@ -9,11 +9,6 @@ const simulateFSA = (
   lambdaCount = 0,
   lastTransitionLambda = false
 ) => {
-  // Are we done processing symbols?
-  if (input.length === 0) {
-    const currState = graph.states.find(state => state.id === currStateID)
-    return { accepted: currState.isFinal, trace, remaining: input }
-  }
 
   // Get next set of possible transitions
   const possibleTransitions = graph.transitions.filter(
@@ -23,9 +18,22 @@ const simulateFSA = (
   // Move lambda transitions to end of array (to prioritise non-lambda transitions)
   possibleTransitions.sort((a, b) => b.read.length - a.read.length)
 
+  const currState = graph.states.find(state => state.id === currStateID)
+
   // No transitions possible?
   if (possibleTransitions.length === 0) {
-    return { accepted: false, trace, remaining: input }
+    // No transitions due to no remaining input
+    if (input.length === 0) {
+      return { accepted: currState.isFinal, trace, remaining: input }
+    // No transitions due to incorrect input character
+    } else {
+      return { accepted: false, trace, remaining: input }
+    }
+  }
+
+  // Are we done processing symbols?
+  if (input.length === 0 && currState.isFinal) {
+    return { accepted: true, trace, remaining: input }
   }
 
   // Continue recurring


### PR DESCRIPTION
Fixes the following:
- Undefined output when running out of input characters on rejected input
- FSA execution not attempting lambda as a final transition(s)
- Skip trace button (user had to press back a step to see accepted/rejected text)

All testing lab outputs *should* be correct and all cases handled:
- Accepted input
- Rejected input due to running out of characters
- Rejected input due to no possible transitions from given character
- Any lambda transitions :))))))))))))

Closes #107 #109 #111